### PR TITLE
README.md: Point to canonical spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,7 +604,7 @@ and [Read the Docs][6].
 
 Installation and user documentation will be added in a future update.
 
- [0]: https://www.freedesktop.org/wiki/Specifications/BootLoaderSpec/
+ [0]: https://systemd.io/BOOT_LOADER_SPECIFICATION
  [1]: https://github.com/bmr-cymru/snapshot-boot-docs
  [2]: https://github.com/bmr-cymru/boom/issues
  [3]: https://www.redhat.com/mailman/listinfo/dm-devel


### PR DESCRIPTION
A note at the top of https://www.freedesktop.org/wiki/Specifications/BootLoaderSpec/ indicates that the document there is out of date, and gives the canonical URL for the BootLoader specification as https://systemd.io/BOOT_LOADER_SPECIFICATION — which is indeed updated relative to the FreeDesktop version. (It contains a more fleshed-out discussion of BLS entries vs. UEFI kernel images, somewhat better organization in general, and has benefited from additional copyediting.)

This change replaces the freedesktop spec link with the provided systemd.io URL.