### PR TITLE
Use abstract base class for profiles

### DIFF
--- a/boom/hostprofile.py
+++ b/boom/hostprofile.py
@@ -1077,7 +1077,7 @@ class HostProfile(OsProfile):
         """
         path = boom_host_profiles_path()
         mode = BOOM_HOST_PROFILE_MODE
-        self._write_profile("Host", self.host_id, path, mode, force=force)
+        self._write_profile(self.host_id, path, mode, force=force)
 
     def delete_profile(self):
         """Delete on-disk data for this profile.

--- a/boom/hostprofile.py
+++ b/boom/hostprofile.py
@@ -705,6 +705,27 @@ class HostProfile(OsProfile):
     #   del_opts
 
     @property
+    def disp_os_id(self):
+        """The display os_id of this profile.
+
+            Return the shortest prefix of this OsProfile's os_id that
+            is unique within the current set of loaded profiles.
+
+            :getter: return this OsProfile's os_id.
+            :type: str
+        """
+        return self.osp.disp_os_id
+
+    @property
+    def os_id(self):
+        """The ``os_id`` of this profile.
+
+            :getter: returns the ``os_id`` as a string.
+            :type: string
+        """
+        return self.osp.os_id
+
+    @property
     def host_id(self):
         if BOOM_HOST_ID not in self._profile_data:
             self._generate_id()

--- a/boom/hostprofile.py
+++ b/boom/hostprofile.py
@@ -621,7 +621,7 @@ class HostProfile(OsProfile):
             self._from_data(profile_data)
             return
         if profile_file:
-            self._from_file(profile_file, "Host")
+            self._from_file(profile_file)
             return
 
         self._dirty()

--- a/boom/hostprofile.py
+++ b/boom/hostprofile.py
@@ -510,7 +510,7 @@ class HostProfile(OsProfile):
 
         self._profile_data[key] = value
 
-    def _generate_host_id(self):
+    def _generate_id(self):
         """Generate a new host identifier.
 
             Generate a new sha1 profile identifier for this profile,
@@ -575,7 +575,7 @@ class HostProfile(OsProfile):
         self._profile_data = dict(host_data)
 
         if BOOM_HOST_ID not in self._profile_data:
-            self._generate_host_id()
+            self._generate_id()
 
         self.__set_os_profile()
 
@@ -661,7 +661,7 @@ class HostProfile(OsProfile):
 
         self.__set_os_profile()
 
-        self._generate_host_id()
+        self._generate_id()
         _host_profiles.append(self)
 
     # We use properties for the HostProfile attributes: this is to
@@ -707,7 +707,7 @@ class HostProfile(OsProfile):
     @property
     def host_id(self):
         if BOOM_HOST_ID not in self._profile_data:
-            self._generate_host_id()
+            self._generate_id()
         return self._profile_data[BOOM_HOST_ID]
 
     @property
@@ -752,7 +752,7 @@ class HostProfile(OsProfile):
             return
         self._profile_data[BOOM_ENTRY_MACHINE_ID] = value
         self._dirty()
-        self._generate_host_id()
+        self._generate_id()
 
     @property
     def os_id(self):
@@ -770,7 +770,7 @@ class HostProfile(OsProfile):
         self._profile_data[BOOM_OS_ID] = value
         self.__set_os_profile()
         self._dirty()
-        self._generate_host_id()
+        self._generate_id()
 
     @property
     def host_name(self):
@@ -790,7 +790,7 @@ class HostProfile(OsProfile):
             return
         self._profile_data[BOOM_HOST_NAME] = value
         self._dirty()
-        self._generate_host_id()
+        self._generate_id()
 
     @property
     def short_name(self):
@@ -1030,7 +1030,7 @@ class HostProfile(OsProfile):
 
         self._profile_data[BOOM_HOST_LABEL] = value
         self._dirty()
-        self._generate_host_id()
+        self._generate_id()
 
     def _profile_path(self):
         """Return the path to this profile's on-disk data.

--- a/boom/hostprofile.py
+++ b/boom/hostprofile.py
@@ -1093,7 +1093,7 @@ class HostProfile(OsProfile):
                      ``ValueError`` if the profile does not exist.
         """
         global _host_profiles, _host_profiles_by_id, _host_profiles_by_host_id
-        self._delete_profile("Host", self.host_id)
+        self._delete_profile(self.host_id)
 
         machine_id = self.machine_id
         host_id = self.host_id

--- a/boom/hostprofile.py
+++ b/boom/hostprofile.py
@@ -395,7 +395,7 @@ def match_host_profile(entry):
     return None
 
 
-class HostProfile(OsProfile):
+class HostProfile(BoomProfile):
     """ Class HostProfile implements Boom host system profiles.
 
         Objects of type HostProfile define a host identiry, and optional
@@ -612,6 +612,10 @@ class HostProfile(OsProfile):
         """
         global _host_profiles
         self._profile_data = {}
+
+        # Initialise BoomProfile base class
+        super(HostProfile, self).__init__(HOST_PROFILE_KEYS,
+                                          HOST_REQUIRED_KEYS, BOOM_HOST_ID)
 
         if profile_data and profile_file:
             raise ValueError("Only one of 'profile_data' or 'profile_file' "

--- a/boom/osprofile.py
+++ b/boom/osprofile.py
@@ -1250,8 +1250,7 @@ class OsProfile(object):
         profile_path_name = BOOM_OS_PROFILE_FORMAT % (profile_id)
         return path_join(boom_profiles_path(), profile_path_name)
 
-    def _write_profile(self, profile_type, profile_id,
-                       profile_dir, mode, force=False):
+    def _write_profile(self, profile_id, profile_dir, mode, force=False):
         """Write helper for profile classes.
 
             Write out this profile's data to a file in Boom format to
@@ -1263,7 +1262,6 @@ class OsProfile(object):
             is not currently marked as dirty (either new, or modified
             since the last load operation) the write will be skipped.
 
-            :param profile_type: The type of profile, Host or Os.
             :param profile_id: The os_id or host_id of this profile.
             :param profile_dir: The directory containing this type.
             :param mode: The mode with which files are created.
@@ -1274,14 +1272,14 @@ class OsProfile(object):
                      renamed, or if setting file permissions on the
                      new entry file fails.
         """
+        ptype = self.__class__.__name__
         if not force and not self._unwritten:
             return
 
         profile_path = self._profile_path()
 
-        _log_debug("Writing %sProfile(%s_id='%s') to '%s'" %
-                   (profile_type, profile_type.lower(), profile_id,
-                    basename(profile_path)))
+        _log_debug("Writing %s(id='%s') to '%s'" %
+                   (ptype, profile_id, basename(profile_path)))
 
         # List of key names for this profile type
         profile_keys = self._profile_keys
@@ -1306,8 +1304,7 @@ class OsProfile(object):
                 pass
             raise e
 
-        _log_debug("Wrote %sProfile (%s_id=%s)'" %
-                   (profile_type, profile_type.lower(), profile_id))
+        _log_debug("Wrote %s (id=%s)'" % (ptype, profile_id))
 
     def write_profile(self, force=False):
         """Write out profile data to disk.
@@ -1330,7 +1327,7 @@ class OsProfile(object):
         """
         path = boom_profiles_path()
         mode = BOOM_PROFILE_MODE
-        self._write_profile("Os", self.os_id, path, mode, force=force)
+        self._write_profile(self.os_id, path, mode, force=force)
 
     def _delete_profile(self, profile_type, profile_id):
         """Deletion helper for profile classes.

--- a/boom/osprofile.py
+++ b/boom/osprofile.py
@@ -1329,7 +1329,7 @@ class OsProfile(object):
         mode = BOOM_PROFILE_MODE
         self._write_profile(self.os_id, path, mode, force=force)
 
-    def _delete_profile(self, profile_type, profile_id):
+    def _delete_profile(self, profile_id):
         """Deletion helper for profile classes.
 
             Remove the on-disk profile corresponding to this
@@ -1372,7 +1372,7 @@ class OsProfile(object):
                      ``ValueError`` if the profile does not exist.
         """
         global _profiles
-        self._delete_profile("Os", self.os_id)
+        self._delete_profile(self.os_id)
         if _profiles and self in _profiles:
             _profiles.remove(self)
         if _profiles_by_id and self.os_id in _profiles_by_id:

--- a/boom/osprofile.py
+++ b/boom/osprofile.py
@@ -615,7 +615,7 @@ class OsProfile(object):
             self._profile_data.pop(self._identity_key)
         self._unwritten = True
 
-    def _generate_os_id(self):
+    def _generate_id(self):
         """Generate a new OS identifier.
 
             Generate a new sha1 profile identifier for this profile,
@@ -676,7 +676,7 @@ class OsProfile(object):
         self._profile_data = dict(profile_data)
 
         if BOOM_OS_ID not in self._profile_data:
-            self._generate_os_id()
+            self._generate_id()
 
         if dirty:
             self._dirty()
@@ -805,7 +805,7 @@ class OsProfile(object):
         for key in _DEFAULT_KEYS:
             self._profile_data[key] = default_if_unset(key)
 
-        self._generate_os_id()
+        self._generate_id()
         self._append_profile()
 
     def match_uname_version(self, version):
@@ -1011,7 +1011,7 @@ class OsProfile(object):
             :type: string
         """
         if BOOM_OS_ID not in self._profile_data:
-            self._generate_os_id()
+            self._generate_id()
         return self._profile_data[BOOM_OS_ID]
 
     @property

--- a/boom/osprofile.py
+++ b/boom/osprofile.py
@@ -683,7 +683,7 @@ class OsProfile(object):
 
         self._append_profile()
 
-    def _from_file(self, profile_file, profile_type):
+    def _from_file(self, profile_file):
         """Initialise a new profile from data stored in a file.
 
             Initialise a new profil object using the profile data
@@ -698,9 +698,10 @@ class OsProfile(object):
         profile_data = {}
         comments = {}
         comment = ""
+        ptype = self.__class__.__name__
 
         _log_debug("Loading %sProfile from '%s'" %
-                   (profile_type, basename(profile_file)))
+                   (ptype, basename(profile_file)))
         with open(profile_file, "r") as pf:
             for line in pf:
                 if blank_or_comment(line):
@@ -767,7 +768,7 @@ class OsProfile(object):
             self._from_data(profile_data)
             return
         if profile_file:
-            self._from_file(profile_file, "Os")
+            self._from_file(profile_file)
             return
 
         self._dirty()


### PR DESCRIPTION
tl;dr: LGTM warns if subclasses do not call the `__init__()` method of their superclasses from their own `__init__()` method. This is required by the Python object system.

Avoid this by splitting out the common parts of `OsProfile` and `HostProfile` into a separate, abstract `BoomProfile` class, and calling the `BoomProfile` initialiser from each concrete profile type.